### PR TITLE
Remove additional elig columns if not needed

### DIFF
--- a/SEQTaRget/DESCRIPTION
+++ b/SEQTaRget/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SEQTaRget
 Type: Package
 Title: Sequential Trial Emulation
-Version: 1.3.6.9005
+Version: 1.3.6.9006
 Authors@R: c(person(given = "Ryan",
                     family = "O'Dea",
                     role = c("aut", "cre"),

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -7,7 +7,7 @@
 - Removed three unused slots in `SEQopts()`.
 - Add alt text to figures in vignettes.
 - Fixed `SEQuential()` `time.col` validation detecting and repairing non-zero-indexed time.
-- Add validation for `eligible.col` values and transition constraint
+- Add validation for `eligible.col` values
 - Add Paul Madley-Dowd as a co-author
 - Add check for overlapping `time_varying.cols` and `fixed.cols`
 - Add bounds validation for numeric and integer options in `SEQopts()`
@@ -18,6 +18,7 @@
 - Add binary check for outcome.col in non-hazard analyses
 - Add `treat.level` length validation for multinomial and non-multinomial analyses
 - Add binary validation for `cense.eligible` and `weight.eligible_cols`
+- Remove additional eligibility rows if not needed
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/R/SEQuential.R
+++ b/SEQTaRget/R/SEQuential.R
@@ -129,9 +129,6 @@ SEQuential <- function(data, id.col, time.col, eligible.col, treatment.col, outc
   elig_vals <- unique(data[[params@eligible]])
   if (!all(elig_vals %in% c(0L, 1L))) stop("'", eligible.col, "' must be binary (0/1) but contains values: ",
                                             paste(setdiff(elig_vals, c(0L, 1L)), collapse = ", "))
-  elig_switches <- data[, sum(abs(diff(get(params@eligible)))), by = eval(params@id)]
-  if (any(elig_switches$V1 > 1L)) stop("'", eligible.col, "' must transition at most once per subject, ",
-                                        "but ", sum(elig_switches$V1 > 1L), " subject(s) have multiple switches")
   if (!is.na(params@cense.eligible)) {
     cense_elig_vals <- unique(data[[params@cense.eligible]])
     if (!all(cense_elig_vals %in% c(0L, 1L))) stop("'", params@cense.eligible, "' (cense.eligible) must be binary (0/1) but contains values: ",

--- a/SEQTaRget/R/SEQuential.R
+++ b/SEQTaRget/R/SEQuential.R
@@ -163,6 +163,10 @@ SEQuential <- function(data, id.col, time.col, eligible.col, treatment.col, outc
     data[, (params@time) := seq(0L, .N - 1L), by = eval(params@id)]
     if (verbose) cat("Repaired\n") else warning("Non zero-indexed time identified, Repair attempted and succeeded\n")
   }
+  
+  # If max elig has been reached, remove future rows
+  data <- data[data[, .I[seq_len(max(which(get(eligible.col) == 1L), 0L))], by = c(id.col)]$V1]
+  
   # Expansion ==================================================
   if (params@verbose) cat("Expanding Data...\n")
   if (params@multinomial) params@data[!get(params@treatment) %in% params@treat.level, eval(params@eligible) := 0]

--- a/SEQTaRget/tests/testthat/test_errors.R
+++ b/SEQTaRget/tests/testthat/test_errors.R
@@ -37,6 +37,19 @@ test_that("Early Column Erroring", {
   expect_error(explore(list(), 2))
 })
 
+test_that("Multiple eligibility switches per subject are accepted (regression: #eligible_col single-transition constraint)", {
+  # Subjects can legitimately become eligible, enter a trial, become ineligible,
+  # then re-enrol — producing multiple 0/1 switches. A prior check incorrectly
+  # rejected such datasets; this test guards against reintroducing that check.
+  multi_switch <- copy(SEQdata)
+  multi_switch[ID == 1 & time %in% c(5, 6, 7), eligible := 0L]  # creates two eligibility windows for subject 1: 1...1,0,0,0,1...
+  expect_no_error(SEQuential(multi_switch,
+    id.col = "ID", time.col = "time", eligible.col = "eligible",
+    treatment.col = "tx_init", outcome.col = "outcome", method = "ITT",
+    time_varying.cols = c("N", "L", "P"), fixed.cols = "sex", options = SEQopts()
+  ))
+})
+
 test_that("Missing Observations in Data", {
   md <- copy(SEQdata)[1, tx_init := NA]
   expect_error(SEQuential(md, "ID", "time", "eligible", "tx_init", "outcome", list("N", "L", "P"), list("sex"),


### PR DESCRIPTION
This little oneliner removes additional columns if there is no future eligibility in an ID's time series - same logic as filtering for the first switch, instead targets the max cumsum of the eligibility column and stops once it reaches there - maybe will help Paul's data.