### PR TITLE
Optimizations to use less RAM and other minor amends

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,6 +46,7 @@ jobs:
           working-directory: SEQTaRget
           extra-packages: any::rcmdcheck
           needs: check
+          upgrade: 'TRUE'
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/SEQTaRget/DESCRIPTION
+++ b/SEQTaRget/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SEQTaRget
 Type: Package
 Title: Sequential Trial Emulation
-Version: 1.3.6.9007
+Version: 1.3.6.9008
 Authors@R: c(person(given = "Ryan",
                     family = "O'Dea",
                     role = c("aut", "cre"),

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -21,6 +21,7 @@
 - Remove additional eligibility rows if not needed
 - Amend defaults for `followup.min` and `weight.lower` from `-Inf` to `0`
 - Fix bootstrapping for risk difference and risk ratio estimates to use paired per-iteration estimates
+- Optimizations to use less RAM
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/R/SEQexpand.R
+++ b/SEQTaRget/R/SEQexpand.R
@@ -43,7 +43,7 @@ SEQexpand <- function(params) {
     vars.sq <- unique(sub(params@indicator.squared, "", vars.sq))
     vars.kept <- c(vars, params@id, "trial", "period", "followup")
 
-    data <- DT[, list(period = Map(seq, get(params@time), .N - 1)), by = eval(params@id),
+    data <- DT[, list(period = Map(seq, get(params@time), pmin(.N - 1, get(params@time) + params@followup.max))), by = eval(params@id),
                ][, cbind(.SD, trial = rowid(get(params@id)) - 1)
                  ][, list(period = unlist(.SD)), by = c(eval(params@id), "trial")
                    ][, followup := as.integer(seq_len(.N) - 1), by = c(eval(params@id), "trial")

--- a/SEQTaRget/R/SEQexpand.R
+++ b/SEQTaRget/R/SEQexpand.R
@@ -17,7 +17,7 @@ SEQexpand <- function(params) {
     trialID <- NULL
     lag <- NULL
     tx_bas <- paste0(params@treatment, params@indicator.baseline)
-    DT <- copy(params@data)
+    DT <- params@data
 
     # Expansion =======================================================
     if (!params@weighted) {

--- a/SEQTaRget/R/SEQexpand.R
+++ b/SEQTaRget/R/SEQexpand.R
@@ -71,6 +71,9 @@ SEQexpand <- function(params) {
     } else if (length(data_list) == 1) {
       out <- data_list[[1]]
     }
+    rm(data_list)
+    if (exists("data.time")) rm(data.time)
+    if (exists("data.base")) rm(data.base)
 
     out <- out[get(paste0(params@eligible, params@indicator.baseline)) == 1,
                ][, paste0(params@eligible, params@indicator.baseline) := NULL]

--- a/SEQTaRget/R/SEQexpand.R
+++ b/SEQTaRget/R/SEQexpand.R
@@ -104,8 +104,9 @@ SEQexpand <- function(params) {
           }
           out[!is.na(isExcused), excused_tmp := cumsum(isExcused), by = c(params@id, "trial")
               ][(excused_tmp) > 0, switch := FALSE, by = c(params@id, "trial")
-                ][, excused_tmp := FALSE]
-        } 
+                ][, excused_tmp := NULL]
+          if ("isExcused" %in% names(out)) out[, isExcused := NULL]
+        }
       }  else {
         # Automatic switch definition (based on treatment and treatment lag)
         out[, lag := shift(get(params@treatment), fill = get(params@treatment)[1]), by = c(params@id, "trial")]
@@ -131,6 +132,7 @@ SEQexpand <- function(params) {
             trial_sq = trial^2,
             switch = get(params@treatment) != shift(get(params@treatment), fill = get(params@treatment)[1])), by = c(params@id, "trial")]
         }
+        out[, lag := NULL]
       }
       out[, firstSwitch := if (any(switch)) which(switch)[1] else .N, by = c(params@id, "trial")]
       out <- out[out[, .I[seq_len(firstSwitch[1])], by = c(params@id, "trial")]$V1

--- a/SEQTaRget/R/internal_analysis.R
+++ b/SEQTaRget/R/internal_analysis.R
@@ -174,19 +174,23 @@ internal.analysis <- function(params) {
         boot_idx = seq_len(n_sample)
       )
     
-      # Integer ID: guaranteed unique if boot_idx < max_periods
-      # e.g., orig_id * 1e6 + boot_idx, or use a pre-computed multiplier
-      id_mult <- max(UIDs) + 1L
-      
-      # Single keyed join instead of n_sample separate filters
+      # Create unique IDs for each bootstrap copy of a subject.
+      # Numeric IDs: use arithmetic (orig_id * multiplier + boot_idx).
+      # Character IDs: use string concatenation (orig_id_b<boot_idx>).
+      if (is.numeric(UIDs)) {
+        id_mult <- max(UIDs) + 1L
+        make_id <- function(id_col, idx) as.integer(id_col * id_mult + idx)
+      } else {
+        make_id <- function(id_col, idx) paste0(id_col, "_b", idx)
+      }
+
       RMDT <- DT[id_lookup, on = setNames("orig_id", params@id), allow.cartesian = TRUE
-                 ][, (params@id) := as.integer(get(params@id) * id_mult + boot_idx)
-                    ][, boot_idx := NULL]
-      
-      
+                 ][, (params@id) := make_id(get(params@id), boot_idx)
+                   ][, boot_idx := NULL]
+
       RMdata <- data[id_lookup, on = setNames("orig_id", params@id), allow.cartesian = TRUE
-                     ][, (params@id) := as.integer(get(params@id) * id_mult + boot_idx)
-                        ][, boot_idx := NULL]
+                     ][, (params@id) := make_id(get(params@id), boot_idx)
+                       ][, boot_idx := NULL]
       
       return(list(RMDT = RMDT, RMdata = RMdata))
     }

--- a/SEQTaRget/R/internal_analysis.R
+++ b/SEQTaRget/R/internal_analysis.R
@@ -178,8 +178,8 @@ internal.analysis <- function(params) {
       # Numeric IDs: use arithmetic (orig_id * multiplier + boot_idx).
       # Character IDs: use string concatenation (orig_id_b<boot_idx>).
       if (is.numeric(UIDs)) {
-        id_mult <- max(UIDs) + 1L
-        make_id <- function(id_col, idx) as.integer(id_col * id_mult + idx)
+        id_mult <- as.numeric(max(UIDs)) + 1
+        make_id <- function(id_col, idx) as.numeric(id_col) * id_mult + idx
       } else {
         make_id <- function(id_col, idx) paste0(id_col, "_b", idx)
       }

--- a/SEQTaRget/R/internal_survival.R
+++ b/SEQTaRget/R/internal_survival.R
@@ -156,13 +156,14 @@ internal.survival <- function(params, outcome) {
 
       if (params@bootstrap.CI_method == "se") {
         z <- qnorm(1 - (1 - params@bootstrap.CI)/2)
+        rm(data_all)
         surv <- full$data[DT.se, on = c("followup", "variable")
                           ][, `:=` (LCI = max(0, value - z*SE), UCI = min(1, value + z*SE)), by = .I]
       } else {
         DT.q <- data_all[, list(LCI = quantile(value, (1 - params@bootstrap.CI)/2),
                                 UCI = quantile(value, 1 - (1 - params@bootstrap.CI)/2)),
                          by = c("followup", "variable")]
-
+        rm(data_all)
         surv <- full$data[DT.se, on = c("followup", "variable")
                           ][DT.q, on = c("followup", "variable")]
       }

--- a/SEQTaRget/R/internal_weights.R
+++ b/SEQTaRget/R/internal_weights.R
@@ -21,6 +21,10 @@ internal.weights <- function(DT, data, params, cache) {
     if (!params@weight.preexpansion) {
       subtable.kept <- c(params@treatment, params@id, params@time)
       params@time <- "period"
+      # DT is passed by reference; a previous handler call (e.g. main analysis before
+      # bootstrap) may have added tx_lag in-place. Remove it so the join below does not
+      # produce an i.tx_lag duplicate column that causes rbind to fail.
+      if ("tx_lag" %in% names(DT)) DT[, tx_lag := NULL]
 
       baseline.lag <- data[, subtable.kept, with = FALSE
                            ][, tx_lag := shift(get(params@treatment)), by = eval(params@id)


### PR DESCRIPTION
This,

* Fix bootstrap ID generation failing for non-numeric (character) ID columns
* Cap trial period sequences at followup.max during expansion to reduce peak
* Fix integer overflow in bootstrap ID generation for large numeric subject IDs
* Free data_all after use in internal.survival to reduce peak RAM
* Remove unnecessary copy() of params@data in SEQexpand to halve RAM during expansion
* Free data_list, data.time and data.base after merge in SEQexpand to reduce peak RAM
* Remove lag after use in SEQexpand censoring logic and fix excused_tmp column deletion
* Fix rbind column mismatch in internal.weights when bootstrap follows main analysis with weight.preexpansion = FALSE