### PR TITLE
Some more optimizations to reduce memory usage

### DIFF
--- a/SEQTaRget/DESCRIPTION
+++ b/SEQTaRget/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SEQTaRget
 Type: Package
 Title: Sequential Trial Emulation
-Version: 1.3.6.9009
+Version: 1.3.6.9010
 Authors@R: c(person(given = "Ryan",
                     family = "O'Dea",
                     role = c("aut", "cre"),

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -28,6 +28,7 @@
 - Fix `km_curve()` subtitle condition
 - Fix `risk.comparison()` CIs being `NA` with competing events
 - Move selection.random before expansion to reduce peak memory usage
+- Replace `cbind()` with `:=` in expansion chain to avoid intermediate copy
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -27,6 +27,7 @@
 - Fix `km_curve()` returning list instead of ggplot for non-subgroup case
 - Fix `km_curve()` subtitle condition
 - Fix `risk.comparison()` CIs being `NA` with competing events
+- Move selection.random before expansion to reduce peak memory usage
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -30,6 +30,7 @@
 - Move selection.random before expansion to reduce peak memory usage
 - Replace `cbind()` with `:=` in expansion chain to avoid intermediate copy
 - Replace `merge()` with data.table native join in expansion data_list combine step
+- Replace rbind weight construction with copy+in-place to reduce peak memory
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -31,6 +31,7 @@
 - Replace `cbind()` with `:=` in expansion chain to avoid intermediate copy
 - Replace `merge()` with data.table native join in expansion data_list combine step
 - Replace rbind weight construction with copy+in-place to reduce peak memory
+- Drop wt and tmp columns immediately after weight is computed in all code paths
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -29,6 +29,7 @@
 - Fix `risk.comparison()` CIs being `NA` with competing events
 - Move selection.random before expansion to reduce peak memory usage
 - Replace `cbind()` with `:=` in expansion chain to avoid intermediate copy
+- Replace `merge()` with data.table native join in expansion data_list combine step
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -32,6 +32,7 @@
 - Replace `merge()` with data.table native join in expansion data_list combine step
 - Replace rbind weight construction with copy+in-place to reduce peak memory
 - Drop wt and tmp columns immediately after weight is computed in all code paths
+- Remove redundant setDF calls in fast_model_matrix
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/R/SEQexpand.R
+++ b/SEQTaRget/R/SEQexpand.R
@@ -80,7 +80,7 @@ SEQexpand <- function(params) {
       data_list[["base"]] <- data.base[, vars.found, with = FALSE]
     }
     if (length(data_list) > 1) {
-      out <- Reduce(function(x, y) merge(x, y, by = c(params@id, "trial", "period"), all = TRUE), data_list)
+      out <- Reduce(function(x, y) x[y, on = c(params@id, "trial", "period"), nomatch = NULL], data_list)
     } else if (length(data_list) == 1) {
       out <- data_list[[1]]
     }

--- a/SEQTaRget/R/SEQexpand.R
+++ b/SEQTaRget/R/SEQexpand.R
@@ -16,6 +16,7 @@ SEQexpand <- function(params) {
     firstSwitch <- NULL
     trialID <- NULL
     lag <- NULL
+    treatment_val <- NULL
     tx_bas <- paste0(params@treatment, params@indicator.baseline)
     DT <- params@data
 
@@ -49,6 +50,18 @@ SEQexpand <- function(params) {
                    ][, followup := as.integer(seq_len(.N) - 1), by = c(eval(params@id), "trial")
                      ][followup <= params@followup.max,
                        ][followup >= params@followup.min, ]
+
+    if (params@selection.random && !params@selection.first_trial) {
+      set.seed(params@seed)
+      eligible_starts <- DT[get(params@eligible) == 1,
+                             list(trialID = paste0(get(params@id), "-", get(params@time)),
+                                  treatment_val = get(params@treatment))]
+      IDs_treated <- unique(eligible_starts[treatment_val != params@treat.level[[1]], trialID])
+      set_control <- unique(eligible_starts[treatment_val == params@treat.level[[1]], trialID])
+      subset_control <- sample(set_control, round(length(set_control) * params@selection.prob))
+      data[, trialID := paste0(get(params@id), "-", trial)]
+      data <- data[trialID %in% c(IDs_treated, subset_control)][, trialID := NULL]
+    }
 
     data_list <- list()
     if (length(c(vars.time, vars.sq)) > 0) {
@@ -147,14 +160,5 @@ SEQexpand <- function(params) {
                    ][, "trial.first" := NULL]
     }
     
-    if (params@selection.random) {
-      set.seed(params@seed)
-      out[, "trialID" := paste0(params@id, "-", trial)]
-      IDs <- unique(out[get(paste0(params@treatment, params@indicator.baseline)) != params@treat.level[[1]], ][["trialID"]])
-      set <- unique(out[get(paste0(params@treatment, params@indicator.baseline)) == params@treat.level[[1]], ][["trialID"]])
-      subset <- sample(set, round(length(set) * params@selection.prob))
-      out <- out[trialID %in% c(IDs, subset),
-                 ][, trialID := NULL]
-    }
   return(out)
 }

--- a/SEQTaRget/R/SEQexpand.R
+++ b/SEQTaRget/R/SEQexpand.R
@@ -45,7 +45,7 @@ SEQexpand <- function(params) {
     vars.kept <- c(vars, params@id, "trial", "period", "followup")
 
     data <- DT[, list(period = Map(seq, get(params@time), pmin(.N - 1, get(params@time) + params@followup.max))), by = eval(params@id),
-               ][, cbind(.SD, trial = rowid(get(params@id)) - 1)
+               ][, trial := rowid(get(params@id)) - 1
                  ][, list(period = unlist(.SD)), by = c(eval(params@id), "trial")
                    ][, followup := as.integer(seq_len(.N) - 1), by = c(eval(params@id), "trial")
                      ][followup <= params@followup.max,

--- a/SEQTaRget/R/internal_analysis.R
+++ b/SEQTaRget/R/internal_analysis.R
@@ -81,7 +81,8 @@ internal.analysis <- function(params) {
                                   ][, tmp := cumsum(ifelse(is.na(isExcused), 0, isExcused)), by = c(eval(params@id), "trial")
                                    ][tmp > 0, wt := 1, by = c(eval(params@id), "trial")
                                      ][, weight := cumprod(ifelse(is.na(wt), 1, wt)), by = c(eval(params@id), "trial")
-                                       ][, weight := weight[1], list(cumsum(!is.na(weight)))]
+                                       ][, weight := weight[1], list(cumsum(!is.na(weight)))
+                                         ][, c("wt", "tmp") := NULL]
           } else {
             # Static - pre-expansion
             params@time <- "period"
@@ -91,7 +92,7 @@ internal.analysis <- function(params) {
                           ][, wt := numerator / denominator
                             ][is.na(wt), wt := 1
                               ][, weight := cumprod(wt), by = c(eval(params@id), "trial")
-                                ][, trial.first := NULL]
+                                ][, c("wt", "trial.first") := NULL]
           }
         } else {
           if (params@excused | params@deviation.excused) {
@@ -107,7 +108,8 @@ internal.analysis <- function(params) {
                                     ][, tmp := cumsum(ifelse(is.na(isExcused), 0, isExcused)), by = c(eval(params@id), "trial")
                                       ][tmp > 0, wt := 1, by = c(eval(params@id), "trial")
                                         ][, weight := cumprod(ifelse(is.na(wt), 1, wt)), by = c(eval(params@id), "trial")
-                                          ][, weight := weight[1], list(cumsum(!is.na(weight)))]
+                                          ][, weight := weight[1], list(cumsum(!is.na(weight)))
+                                            ][, c("wt", "tmp") := NULL]
           } else {
             # Static - post-expansion
             params@time <- "period"
@@ -116,7 +118,8 @@ internal.analysis <- function(params) {
                         ][, wt := numerator / denominator
                           ][is.na(wt), wt := 1
                             ][followup == 0, wt := 1
-                              ][, weight := cumprod(wt), by = c(eval(params@id), "trial")]
+                              ][, weight := cumprod(wt), by = c(eval(params@id), "trial")
+                                ][, wt := NULL]
           }
         }
         if (params@LTFU) WDT[, weight := weight * cense1]

--- a/SEQTaRget/R/internal_fatglmHelpers.R
+++ b/SEQTaRget/R/internal_fatglmHelpers.R
@@ -161,18 +161,16 @@ prepare.data_cached <- function(weight, params, type, model, case, cache) {
 
 # Fast model matrix builder - avoids overhead for simple cases
 fast_model_matrix <- function(formula, data, cols, is_simple = FALSE) {
-  # Extract only needed columns as data.frame (model.matrix requires it)
-  # Using as.data.frame.list is faster than as.data.frame.data.table
-  subset_data <- setDF(data[, ..cols])
-  
-  # Fast path for simple additive numeric-only models
+  subset_data <- data[, ..cols]
+
+  # Fast path for simple additive numeric-only models: no setDF needed
   if (isTRUE(is_simple) && all(vapply(subset_data, is.numeric, logical(1)))) {
     X <- as.matrix(subset_data)
     X <- cbind(Intercept = 1, X)
     return(X)
   }
-  
-  # Standard path
+
+  # Standard path: setDF in-place on the temp subset, then model.matrix
   X <- model.matrix(formula, data = setDF(subset_data), na.action = stats::na.pass)
   return(X)
 }

--- a/SEQTaRget/R/internal_weights.R
+++ b/SEQTaRget/R/internal_weights.R
@@ -10,7 +10,7 @@
 #' @keywords internal
 internal.weights <- function(DT, data, params, cache) {
   # Variable pre-definition ===================================
-    tx_lag <- NULL
+    tx_lag <- i.tx_lag <- NULL
     numerator <- denominator <- NULL
     cense1 <- cense1.numerator <- cense1.denominator <- NULL
     followup <- NULL
@@ -32,12 +32,11 @@ internal.weights <- function(DT, data, params, cache) {
                                ][, eval(params@treatment) := NULL]
 
       setnames(baseline.lag, 2, params@time)
-      # Conditional join
-      weight <- rbind(
-        DT[followup == 0,
-           ][baseline.lag, on = c(params@id, params@time), nomatch = 0],
-        DT[, tx_lag := shift(get(params@treatment)), by = c(eval(params@id), "trial")
-           ][followup != 0, ])[, paste0(params@time, params@indicator.squared) := get(params@time)^2]
+      weight <- copy(DT)
+      weight[, tx_lag := shift(get(params@treatment)), by = c(eval(params@id), "trial")]
+      weight[baseline.lag, on = c(params@id, params@time),
+             tx_lag := fifelse(followup == 0L, i.tx_lag, tx_lag)]
+      weight[, paste0(params@time, params@indicator.squared) := get(params@time)^2]
 
       if (params@excused | params@deviation.excused) weight[, isExcused := cumsum(ifelse(is.na(isExcused), 0, isExcused)), by = c(eval(params@id), "trial")]
 


### PR DESCRIPTION
- Move selection.random before expansion to reduce peak memory usage
- Replace `cbind()` with `:=` in expansion chain to avoid intermediate copy
- Replace `merge()` with data.table native join in expansion data_list combine step
- Replace rbind weight construction with copy+in-place to reduce peak memory
- Drop wt and tmp columns immediately after weight is computed in all code paths
- Remove redundant setDF calls in fast_model_matrix
