### PR TITLE
Some more memory optimizations

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -18,7 +18,7 @@ permissions: read-all
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}

--- a/SEQTaRget/DESCRIPTION
+++ b/SEQTaRget/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SEQTaRget
 Type: Package
 Title: Sequential Trial Emulation
-Version: 1.3.6.9011
+Version: 1.3.6.9012
 Authors@R: c(person(given = "Ryan",
                     family = "O'Dea",
                     role = c("aut", "cre"),

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -42,6 +42,7 @@
 - Avoid `copy()` in data_all construction and free data list in internal_survival.R to reduce peak memory during bootstrap
 - Filter to `followup==0` before adding trialID in internal.survival to avoid copying entire expanded dataset
 - Trim base_DT to only prediction-needed columns before replication in internal.survival to reduce peak memory
+- Remove unnecessary copy(weight) for model.data in internal.weights since it is never modified in-place
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -40,6 +40,7 @@
 - Free result list after extraction in internal_survival.R to reduce peak memory during bootstrap
 - Free analytic list after subgroup loop in SEQuential.R to reduce peak memory during survival curve computation
 - Avoid `copy()` in data_all construction and free data list in internal_survival.R to reduce peak memory during bootstrap
+- Filter to `followup==0` before adding trialID in internal.survival to avoid copying entire expanded dataset
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -43,6 +43,7 @@
 - Filter to `followup==0` before adding trialID in internal.survival to avoid copying entire expanded dataset
 - Trim base_DT to only prediction-needed columns before replication in internal.survival to reduce peak memory
 - Remove unnecessary copy(weight) for model.data in internal.weights since it is never modified in-place
+- Free baseDT after bootstrap loop in internal.survival to reduce peak memory during survival curve computation
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/NEWS.md
+++ b/SEQTaRget/NEWS.md
@@ -41,6 +41,7 @@
 - Free analytic list after subgroup loop in SEQuential.R to reduce peak memory during survival curve computation
 - Avoid `copy()` in data_all construction and free data list in internal_survival.R to reduce peak memory during bootstrap
 - Filter to `followup==0` before adding trialID in internal.survival to avoid copying entire expanded dataset
+- Trim base_DT to only prediction-needed columns before replication in internal.survival to reduce peak memory
 
 # SEQTaRget v1.3.6
 

--- a/SEQTaRget/R/internal_survival.R
+++ b/SEQTaRget/R/internal_survival.R
@@ -136,6 +136,7 @@ internal.survival <- function(params, outcome) {
           return(out)
         })
       }
+      rm(baseDT)
       data <- lapply(seq_along(result), function(x) result[[x]]$data)
       ce.models <- lapply(seq_along(result), function(x) result[[x]]$ce.model)
       rm(result)

--- a/SEQTaRget/R/internal_survival.R
+++ b/SEQTaRget/R/internal_survival.R
@@ -86,8 +86,10 @@ internal.survival <- function(params, outcome) {
       return(list(data = out, ce.model = if (!is.na(params@compevent)) ce.model else NA))
     }
 
-    full <- handler(copy(params@DT)[, "trialID" := paste0(get(params@id), "_", 0, get("trial"))
-                                    ][get("followup") == 0, ], params, outcome[[1]]$model, formula_cache)
+    baseDT_main <- params@DT[get("followup") == 0, ]
+    baseDT_main[, "trialID" := paste0(get(params@id), "_", 0, get("trial"))]
+    full <- handler(baseDT_main, params, outcome[[1]]$model, formula_cache)
+    rm(baseDT_main)
     
     if (params@bootstrap) {
       UIDs <- unique(params@DT[[params@id]])

--- a/SEQTaRget/R/internal_survival.R
+++ b/SEQTaRget/R/internal_survival.R
@@ -27,9 +27,11 @@ internal.survival <- function(params, outcome) {
         rm(ce.data)
       }
       
-      # Get baseline columns (everything except followup-related)
-      base_cols <- names(DT)[!names(DT) %in% c("followup", paste0("followup", params@indicator.squared))]
-      base_DT <- DT[, base_cols, with = FALSE]
+      # Only keep columns needed for prediction to minimize memory during replication
+      fup_sq_col <- paste0("followup", params@indicator.squared)
+      pred_cols <- unique(c(cache$covariates$cols, tx_bas))
+      pred_cols <- pred_cols[!pred_cols %in% c("followup", fup_sq_col, "dose", "dose_sq")]
+      base_DT <- DT[, pred_cols, with = FALSE]
       n_base <- nrow(base_DT)
 
       out_list <- c()
@@ -39,7 +41,6 @@ internal.survival <- function(params, outcome) {
         risk <- paste0("risk_", params@treat.level[[i]])
 
         # Vectorised predictions across all followup steps at once
-        fup_sq_col <- paste0("followup", params@indicator.squared)
         n_fup <- params@survival.max + 1L
         fup_seq <- 0L:as.integer(params@survival.max)
 

--- a/SEQTaRget/R/internal_weights.R
+++ b/SEQTaRget/R/internal_weights.R
@@ -48,7 +48,7 @@ internal.weights <- function(DT, data, params, cache) {
 
     # Modeling ======================================================
     if (params@method == "ITT" || params@LTFU || !is.na(params@visit)) {
-      model.data <- copy(weight)
+      model.data <- weight
       if (params@LTFU) {
         if (!is.na(params@cense.eligible)) model.data <- model.data[get(params@cense.eligible) == 1, ]
         
@@ -82,7 +82,7 @@ internal.weights <- function(DT, data, params, cache) {
     denominator_models <- list()
     
     if (params@method != "ITT") {
-      model.data <- copy(weight)
+      model.data <- weight
       if (!params@weight.preexpansion & !(params@excused | params@deviation.excused)) model.data <- model.data[followup > 0, ]
       
       # Fit models for each treatment level


### PR DESCRIPTION
- Filter to `followup==0` before adding trialID in internal.survival to avoid copying entire expanded dataset
- Trim base_DT to only prediction-needed columns before replication in internal.survival to reduce peak memory
- Remove unnecessary copy(weight) for model.data in internal.weights since it is never modified in-place
- Free baseDT after bootstrap loop in internal.survival to reduce peak memory during survival curve computation
