### PR TITLE
Skip protocol censoring in `SEQexpand` when `expand.only = TRUE`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ rsconnect/
 docs/
 SEQTaRget/docs
 *.html
+.Rproj.user
+.positai

--- a/SEQTaRget/.Rbuildignore
+++ b/SEQTaRget/.Rbuildignore
@@ -15,3 +15,4 @@ sticker.R
 ^pkgdown$
 ^docs$
 ^README\.Rmd$
+^\.positai$

--- a/SEQTaRget/DESCRIPTION
+++ b/SEQTaRget/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SEQTaRget
 Type: Package
 Title: Sequential Trial Emulation
-Version: 1.4.1.9001
+Version: 1.4.1.9002
 Authors@R: c(person(given = "Ryan",
                     family = "O'Dea",
                     role = c("aut", "cre"),

--- a/SEQTaRget/R/SEQexpand.R
+++ b/SEQTaRget/R/SEQexpand.R
@@ -104,7 +104,7 @@ SEQexpand <- function(params) {
       )]
     }
 
-    if (params@method == "censoring") {
+    if (params@method == "censoring" && !params@expand.only) {
       out[, switch := FALSE]
       if (params@deviation) {
         # Censoring on deviation condition


### PR DESCRIPTION
When `expand.only = TRUE` Alejandro wants the raw expanded dataset for inspection, so this avoids applying the censoring when that is specified.